### PR TITLE
Remove unused os variable from the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
         elixir_version: [1.12.3, 1.13.3, 1.14.1]
         otp_version: [24, 25]
         exclude:


### PR DESCRIPTION
The top-level `runs-on` value has been pinned to `ubuntu-latest` and this `os` variable has no place to live when running tests, resulting in only doubling the workload for no benefits.

Although we can actually start to test on the both os versions, this commit does not go for it and chooses to use `ubuntu-latest` solely.

This is because it is hard to imagine that the os version affects the outcome as long as the versions of otp and elixir are set, and this is what the popular libraries like plug and phoenix use as their strategy[^1][^2].

[^1]: https://github.com/elixir-plug/plug/blob/v1.15.2/.github/workflows/ci.yml
[^2]: https://github.com/phoenixframework/phoenix/blob/v1.7.10/.github/workflows/ci.yml